### PR TITLE
Handle 401 code in Auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,5 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run lint task
         run: task lint
+      - name: Run test task
+        run: task test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,5 +97,7 @@ jobs:
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Activate virtual environment
+        run: source $(poetry env info --path)/bin/activate
       - name: Run test task
         run: task test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,13 @@ jobs:
             ~/.cache/pypoetry/artifacts
           key: poetry-${{ runner.os }}-${{ runner.arch }}-py-${{ matrix.python-version }}-poetry-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
-        run: poetry install --with dev
+        run: |
+          poetry install
+          echo $(poetry env info --path)/bin >> $GITHUB_PATH
       - name: Install task
         uses: arduino/setup-task@v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Activate virtual environment
-        run: source $(poetry env info --path)/bin/activate
       - name: Run test task
         run: task test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
             ~/.cache/pypoetry/artifacts
           key: poetry-${{ runner.os }}-${{ runner.arch }}-py-${{ matrix.python-version }}-poetry-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
-        run: poetry install
+        run: |
+          poetry install
+          echo $(poetry env info --path)/bin >> $GITHUB_PATH
       - name: Install task
         uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,51 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run lint task
         run: task lint
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        python-version:
+          - 3.8
+          - 3.9
+          - "3.10"
+          - 3.11
+          - 3.12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+        with:
+          path: |
+            ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ runner.arch }}-py-${{ matrix.python-version }}
+      - name: Install poetry
+        run: pipx install poetry --python python${{ matrix.python-version }}
+      - name: Cache poetry
+        uses: actions/cache@v4
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "15"
+        with:
+          path: |
+            ~/.cache/pypoetry/virtualenvs
+            ~/.cache/pypoetry/cache
+            ~/.cache/pypoetry/artifacts
+          key: poetry-${{ runner.os }}-${{ runner.arch }}-py-${{ matrix.python-version }}-poetry-${{ hashFiles('poetry.lock') }}
+      - name: Install dependencies
+        run: poetry install --with dev
+      - name: Install task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run test task
         run: task test

--- a/asknews_sdk/api/chat.py
+++ b/asknews_sdk/api/chat.py
@@ -21,7 +21,6 @@ class ChatAPI(BaseAPI):
     def get_chat_completions(
         self,
         messages: List[Dict[str, str]],
-        user: str | None = None,
         model: Literal[
             "gpt-3.5-turbo-16k",
             "gpt-4-1106-preview",
@@ -76,7 +75,6 @@ class ChatAPI(BaseAPI):
                 append_references=append_references,
                 asknews_watermark=asknews_watermark,
                 journalist_mode=journalist_mode,
-                user=user,
             ).model_dump(mode="json"),
             headers={
                 **(http_headers or {}),
@@ -158,7 +156,6 @@ class AsyncChatAPI(BaseAPI):
     async def get_chat_completions(
         self,
         messages: List[Dict[str, str]],
-        user: str | None = None,
         model: Literal[
             "gpt-3.5-turbo-16k",
             "gpt-4-1106-preview",
@@ -214,7 +211,6 @@ class AsyncChatAPI(BaseAPI):
                 append_references=append_references,
                 asknews_watermark=asknews_watermark,
                 journalist_mode=journalist_mode,
-                user=user,
             ).model_dump(mode="json"),
             headers={
                 "Content-Type": CreateChatCompletionRequest.__content_type__,

--- a/asknews_sdk/dto/sentiment.py
+++ b/asknews_sdk/dto/sentiment.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Union
 
 from pydantic import AwareDatetime, BaseModel, Field
 from typing_extensions import Annotated
@@ -10,7 +10,7 @@ from asknews_sdk.dto.base import BaseSchema
 
 class FinanceResponseTimeSeriesData(BaseModel):
     datetime: Annotated[AwareDatetime, Field(title="Datetime")]
-    value: Annotated[int | float, Field(title="Value")]
+    value: Annotated[Union[int, float], Field(title="Value")]
 
 
 class FinanceResponseTimeSeries(BaseModel):

--- a/asknews_sdk/dto/stories.py
+++ b/asknews_sdk/dto/stories.py
@@ -125,7 +125,7 @@ class StoryResponse(BaseSchema):
     n_articles: Annotated[List[int], Field(title="N Articles")]
     n_updates: Annotated[int, Field(title="N Updates")]
     people: Annotated[List[str], Field(title="People")]
-    reddit_sentiment: Annotated[List[int | float], Field(title="Reddit Sentiment")]
+    reddit_sentiment: Annotated[List[Union[int, float]], Field(title="Reddit Sentiment")]
     reddit_sentiment_timestamps: Annotated[List[int], Field(title="Reddit Sentiment Timestamps")]
     rolling_sentiment: Annotated[List[float], Field(title="Rolling Sentiment")]
     sentiment: Annotated[List[int], Field(title="Sentiment")]

--- a/asknews_sdk/dto/stories.py
+++ b/asknews_sdk/dto/stories.py
@@ -56,8 +56,8 @@ class IntraClusterStatistics(BaseModel):
 
 
 class GraphRelationships(BaseModel):
-    nodes: list[dict[Literal["id", "type", "detailed_type"], str]]
-    edges: list[dict[Literal["from", "to", "label"], str]]
+    nodes: List[Dict[Literal["id", "type", "detailed_type"], str]]
+    edges: List[Dict[Literal["from", "to", "label"], str]]
 
 
 class StoryResponseUpdate(BaseModel):

--- a/asknews_sdk/response.py
+++ b/asknews_sdk/response.py
@@ -63,15 +63,14 @@ class APIResponse:
         :rtype: APIResponse
         """
         if stream:
-            match stream_type:
-                case "bytes":
-                    response_body = response.iter_bytes() if sync else response.aiter_bytes()
-                case "lines":
-                    response_body = response.iter_lines() if sync else response.aiter_lines()
-                case "raw":
-                    response_body = response.iter_raw() if sync else response.aiter_raw()
-                case _:
-                    raise ValueError(f"Invalid stream type: {stream_type}")
+            if stream_type == "bytes":
+                response_body = response.iter_bytes() if sync else response.aiter_bytes()
+            elif stream_type == "lines":
+                response_body = response.iter_lines() if sync else response.aiter_lines()
+            elif stream_type == "raw":
+                response_body = response.iter_raw() if sync else response.aiter_raw()
+            else:
+                raise ValueError(f"Invalid stream type: {stream_type}")
         else:
             response_body = response.content
 
@@ -134,19 +133,16 @@ class EventSource:
 
         key, value = key.strip(), value.strip()
 
-        match key:
-            case "event":
-                self.current_event.event = value
-            case "data":
-                self.current_event.data.append(value)
-            case "id":
-                self.current_event.id = value
-            case "retry":
-                try:
-                    self.current_event.retry = int(value)
-                except ValueError:
-                    pass
-            case _:
+        if key == "event":
+            self.current_event.event = value
+        elif key == "data":
+            self.current_event.data.append(value)
+        elif key == "id":
+            self.current_event.id = value
+        elif key == "retry":
+            try:
+                self.current_event.retry = int(value)
+            except ValueError:
                 pass
 
     @classmethod


### PR DESCRIPTION
This PR implements the modifications needed to support the case of the OAuth2ClientCredentials attempting to get a new token once if the response from the API is Unauthorized. This is to ensure no requests are lost when the slim chance of a token getting expired in transit to the API.